### PR TITLE
test: increase mutation coverage for SampleMath

### DIFF
--- a/45_IntegrationHub/src/test/java/io/forest/integrationhub/util/SampleMathTest.java
+++ b/45_IntegrationHub/src/test/java/io/forest/integrationhub/util/SampleMathTest.java
@@ -23,4 +23,9 @@ class SampleMathTest {
     void addOverflowThrows() {
         assertThrows(IllegalArgumentException.class, () -> SampleMath.add(Integer.MAX_VALUE, 1));
     }
+
+    @Test
+    void addMaxPlusZeroDoesNotThrow() {
+        assertEquals(Integer.MAX_VALUE, SampleMath.add(Integer.MAX_VALUE, 0));
+    }
 }


### PR DESCRIPTION
Add targeted test to kill conditional-boundary mutant in SampleMath.add; raises mutation score above threshold.