### PR TITLE
chore: bump pitest-junit5-plugin to 1.2.1

### DIFF
--- a/45_IntegrationHub/pom.xml
+++ b/45_IntegrationHub/pom.xml
@@ -65,7 +65,7 @@
 					<dependency>
 						<groupId>org.pitest</groupId>
 						<artifactId>pitest-junit5-plugin</artifactId>
-						<version>0.15</version>
+						<version>1.2.1</version>
 					</dependency>
 				</dependencies>
 				<executions>


### PR DESCRIPTION
Bump org.pitest:pitest-junit5-plugin to 1.2.1 to avoid AbstractMethodError in coverage minion (compat with Pitest 1.19.5).