### PR TITLE
ci: run Pitest against 45_IntegrationHub

### DIFF
--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -38,8 +38,9 @@ jobs:
             ${{ runner.os }}-m2-
 
       - name: Run Pitest (clean JVM args)
+        working-directory: 45_IntegrationHub
         env:
           JAVA_TOOL_OPTIONS: ''
           MAVEN_OPTS: ''
         run: |
-          mvn -B -V -Dcheckstyle.skip=true -Denable.quality.enforcements=true verify
+          mvn -B -V -f 45_IntegrationHub/pom.xml -Dcheckstyle.skip=true -Denable.quality.enforcements=true verify

--- a/45_IntegrationHub/pom.xml
+++ b/45_IntegrationHub/pom.xml
@@ -107,6 +107,29 @@
 						</goals>
 						<phase>verify</phase>
 					</execution>
+
+					<execution>
+						<id>pitest-adapters</id>
+						<goals>
+							<goal>mutationCoverage</goal>
+						</goals>
+						<phase>verify</phase>
+						<configuration>
+							<targetClasses>
+								<param>io.forest.integrationhub.adapters.*</param>
+							</targetClasses>
+							<targetTests>
+								<param>io.forest.integrationhub.*</param>
+							</targetTests>
+							<threads>2</threads>
+							<outputFormats>
+								<param>HTML</param>
+							</outputFormats>
+							<verbose>true</verbose>
+							<failWhenNoMutations>false</failWhenNoMutations>
+							<mutationThreshold>80</mutationThreshold>
+						</configuration>
+					</execution>
 				</executions>
 				<configuration>
 					<targetClasses>

--- a/45_IntegrationHub/pom.xml
+++ b/45_IntegrationHub/pom.xml
@@ -32,6 +32,12 @@
 			<version>${archunit.version}</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>com.google.protobuf</groupId>
+			<artifactId>protobuf-java</artifactId>
+			<version>3.24.3</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Run Maven in 45_IntegrationHub so Pitest uses the correct project POM and plugin configuration; clear injected JVM envs.